### PR TITLE
destroying and recloning library per each destroyinfra/deploy command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,9 +102,13 @@ fn main() {
             utils::run_cmd_on_dir("gg run --profile=.gg/local", "building clients in game/dist folder...", ".");
         }
         Command::Deploy { profile } => {
+            let dir = format!(".omgdtmp/{}", profile);
+
+            let rm_dir_cmd = format!("rm -rf {}", dir);
+            utils::run_cmd_on_dir(&rm_dir_cmd, "rm'ing old tmp repo...", ".");
+
             utils::run_cmd_on_dir("mkdir .omgdtmp", "creating temporary dir...", ".");
 
-            let dir = format!(".omgdtmp/{}", profile);
             let git_clone_cmd = format!("git clone . {}", dir);
             utils::run_cmd_on_dir(&git_clone_cmd, "cloning repo...", ".");
 
@@ -118,6 +122,20 @@ fn main() {
         }
         Command::DestroyInfra { profile } => {
             let dir = format!(".omgdtmp/{}", profile);
+
+            let rm_dir_cmd = format!("rm -rf {}", dir);
+            utils::run_cmd_on_dir(&rm_dir_cmd, "rm'ing old tmp repo...", ".");
+
+            utils::run_cmd_on_dir("mkdir .omgdtmp", "creating temporary dir...", ".");
+
+            let git_clone_cmd = format!("git clone . {}", dir);
+            utils::run_cmd_on_dir(&git_clone_cmd, "cloning repo...", ".");
+
+            let profile_copy = format!("cp -rf profiles {}", dir);
+            utils::run_cmd_on_dir(&profile_copy, "copying profile dir...", ".");
+
+            utils::run_cmd_on_dir("omgd build-profiles", "building profiles...", &dir);
+
             let cmd = format!("gg run task destroy-infra --profile=.gg/{}", profile);
             utils::run_cmd_on_dir(&cmd, "destroying infra...", &dir);
         }


### PR DESCRIPTION
closes #33

should probably be refactored eventually to reduce repetitive code but until I've got a better understanding of the module approach, forgoing