### PR TITLE
62 copying project on infra and deploy should be optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
 build:
-	go build -o ${GOPATH}/bin/omgdev
-
-build-prod:
 	go build -o ${GOPATH}/bin/omgd
 
 test:

--- a/cmd/infra.go
+++ b/cmd/infra.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var StayInDir bool
+
 // infraCmd represents the infra command
 var infraCmd = &cobra.Command{
 	Use:   "infra",
@@ -23,10 +25,11 @@ $ omgd infra destroy | Destroys cloud infrastructure via terraform`,
 		fmt.Println("infra called")
 
 		infraChange := utils.InfraChange{
-			OutputDir:   OutputDir,
-			ProfilePath: ProfilePath,
-			CmdOnDir:    utils.CmdOnDir,
-			Verbosity:   Verbosity,
+			OutputDir:    OutputDir,
+			ProfilePath:  ProfilePath,
+			CmdOnDir:     utils.CmdOnDir,
+			Verbosity:    Verbosity,
+			CopyToTmpDir: !StayInDir,
 		}
 
 		switch args[0] {
@@ -52,4 +55,5 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// infraCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	infraCmd.Flags().BoolVar(&StayInDir, "stay-in-dir", false, "Doesn't perform a copy of the project and makes all infra deploy operations within the directory")
 }

--- a/cmd/infra.go
+++ b/cmd/infra.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var StayInDir bool
+var CopyToTmpDir bool
 
 // infraCmd represents the infra command
 var infraCmd = &cobra.Command{
@@ -29,7 +29,7 @@ $ omgd infra destroy | Destroys cloud infrastructure via terraform`,
 			ProfilePath:  ProfilePath,
 			CmdOnDir:     utils.CmdOnDir,
 			Verbosity:    Verbosity,
-			CopyToTmpDir: !StayInDir,
+			CopyToTmpDir: CopyToTmpDir,
 		}
 
 		switch args[0] {
@@ -55,5 +55,5 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// infraCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	infraCmd.Flags().BoolVar(&StayInDir, "stay-in-dir", false, "Doesn't perform a copy of the project and makes all infra deploy operations within the directory")
+	infraCmd.Flags().BoolVar(&CopyToTmpDir, "copy", false, "Copies the project to an .omgdtmp folder and executes all commands there")
 }

--- a/utils/infra.go
+++ b/utils/infra.go
@@ -22,28 +22,28 @@ func (infraChange *InfraChange) DeployClientAndServer() {
 	infraChange.CmdOnDir(
 		fmt.Sprintf("omgd run task set-ip-to-profile --profile=%s", infraChange.ProfilePath),
 		"",
-		fmt.Sprintf("%s/.omgdtmp", infraChange.OutputDir),
+		infraChange.OutputDir,
 		infraChange.Verbosity,
 	)
 
 	infraChange.CmdOnDir(
 		fmt.Sprintf("omgd build-templates --profile=%s", infraChange.ProfilePath),
 		"",
-		fmt.Sprintf("%s/.omgdtmp", infraChange.OutputDir),
+		infraChange.OutputDir,
 		infraChange.Verbosity,
 	)
 
 	infraChange.CmdOnDir(
 		fmt.Sprintf("omgd build-clients --profile=%s", infraChange.ProfilePath),
 		"",
-		fmt.Sprintf("%s/.omgdtmp", infraChange.OutputDir),
+		infraChange.OutputDir,
 		infraChange.Verbosity,
 	)
 
 	infraChange.CmdOnDir(
 		fmt.Sprintf("omgd run nakama-server --profile=%s", infraChange.ProfilePath),
 		"",
-		fmt.Sprintf("%s/.omgdtmp", infraChange.OutputDir),
+		infraChange.OutputDir,
 		infraChange.Verbosity,
 	)
 }

--- a/utils/infra.go
+++ b/utils/infra.go
@@ -8,11 +8,12 @@ import (
 )
 
 type InfraChange struct {
-	OutputDir   string
-	ProfilePath string
-	CmdOnDir    func(string, string, string, bool)
-	Verbosity   bool
-	tmpDir      string
+	OutputDir    string
+	ProfilePath  string
+	CmdOnDir     func(string, string, string, bool)
+	Verbosity    bool
+	tmpDir       string
+	CopyToTmpDir bool
 }
 
 func (infraChange *InfraChange) DeployClientAndServer() {
@@ -54,7 +55,7 @@ func (infraChange *InfraChange) DeployInfra() {
 	infraChange.CmdOnDir(
 		fmt.Sprintf("omgd run task deploy-infra --profile=%s", infraChange.ProfilePath),
 		"",
-		fmt.Sprintf("%s/.omgdtmp", infraChange.OutputDir),
+		infraChange.OutputDir,
 		infraChange.Verbosity,
 	)
 }
@@ -66,7 +67,7 @@ func (infraChange *InfraChange) DestroyInfra() {
 	infraChange.CmdOnDir(
 		fmt.Sprintf("omgd run task destroy-infra --profile=%s", infraChange.ProfilePath),
 		"",
-		fmt.Sprintf("%s/.omgdtmp", infraChange.OutputDir),
+		infraChange.OutputDir,
 		infraChange.Verbosity,
 	)
 }
@@ -75,47 +76,52 @@ func (infraChange *InfraChange) setup() {
 	infraChange.ProfilePath = strings.ReplaceAll(infraChange.ProfilePath, "profiles/", ".omgd/")
 
 	// 1. Should create or empty .omgdtmp directory to work in
-	infraChange.tmpDir = fmt.Sprintf("%s/.omgdtmp", infraChange.OutputDir)
+	if infraChange.CopyToTmpDir {
+		infraChange.tmpDir = infraChange.OutputDir
+		infraChange.tmpDir = fmt.Sprintf("%s/.omgdtmp", infraChange.OutputDir)
 
-	if infraChange.OutputDir == "." {
-		infraChange.tmpDir = ".omgdtmp"
-	}
+		if infraChange.OutputDir == "." {
+			infraChange.tmpDir = ".omgdtmp"
+		}
 
-	_, err := os.Stat(infraChange.tmpDir)
-	if !os.IsNotExist(err) {
-		err = os.RemoveAll(infraChange.tmpDir)
+		_, err := os.Stat(infraChange.tmpDir)
+		if !os.IsNotExist(err) {
+			err = os.RemoveAll(infraChange.tmpDir)
+
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		err = os.Mkdir(infraChange.tmpDir, 0755)
 
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		// 2. Should clone repo at base of dir (? how to test w/o submodules? clone entire base repo maybe?)
+		sccp := StaticCodeCopyPlan{
+			skipPaths: []string{
+				infraChange.tmpDir,
+				".git",
+			},
+		}
+
+		cwd, err := os.Getwd()
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if infraChange.OutputDir == "." {
+			sccp.CopyStaticDirectory(cwd, infraChange.tmpDir)
+		} else {
+			sccp.CopyStaticDirectory(infraChange.OutputDir, infraChange.tmpDir)
+		}
+
+		infraChange.OutputDir = infraChange.tmpDir
 	}
 
-	err = os.Mkdir(infraChange.tmpDir, 0755)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// 2. Should clone repo at base of dir (? how to test w/o submodules? clone entire base repo maybe?)
-	sccp := StaticCodeCopyPlan{
-		skipPaths: []string{
-			infraChange.tmpDir,
-			".git",
-		},
-	}
-
-	cwd, err := os.Getwd()
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if infraChange.OutputDir == "." {
-		sccp.CopyStaticDirectory(cwd, infraChange.tmpDir)
-	} else {
-		sccp.CopyStaticDirectory(infraChange.OutputDir, infraChange.tmpDir)
-	}
-
-	// 3. Build profiles directory in new .omgdtmp dir
-	BuildProfiles(infraChange.tmpDir, infraChange.Verbosity)
+	// 3. Build profiles directory
+	BuildProfiles(infraChange.OutputDir, infraChange.Verbosity)
 }

--- a/utils/infra_test.go
+++ b/utils/infra_test.go
@@ -70,10 +70,11 @@ func TestDeployClientAndServer(t *testing.T) {
 	})
 
 	infraChange := InfraChange{
-		OutputDir:   "static/test/infra_test_dir",
-		ProfilePath: "profiles/staging",
-		CmdOnDir:    testCmdOnDir,
-		Verbosity:   false,
+		OutputDir:    "static/test/infra_test_dir",
+		ProfilePath:  "profiles/staging",
+		CmdOnDir:     testCmdOnDir,
+		Verbosity:    false,
+		CopyToTmpDir: true,
 	}
 
 	infraChange.DeployClientAndServer()
@@ -162,7 +163,7 @@ func TestDeployInfraWithoutCopying(t *testing.T) {
 
 	testCmdOnDirValidResponseSet = []testCmdOnDirResponse{
 		{
-			cmdStr:    "omgd run --profile=.omgd/staging",
+			cmdStr:    "omgd run task deploy-infra --profile=.omgd/staging",
 			cmdDesc:   "",
 			cmdDir:    testDir,
 			verbosity: false,


### PR DESCRIPTION
closes #62 

Also, adjust the `Makefile` to only create one binary; this is because the `omgd` tool self-references itself, and having two versions makes an unnecessary complication. Dev users can always rebuild after switching back to the `main` branch