### PR TITLE
80 profile profile path env semantics

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -10,9 +10,9 @@
       - it's also somewhat questionable. might be patient here for a bit. look into pre existing stubs / spies libs
 
 
-- A GH Issue exists but much confusion between paths and profiles and the idea of an environment -- need to consider approaches
+~~- A GH Issue exists but much confusion between paths and profiles and the idea of an environment -- need to consider approaches
   - Currently trying to mimic old OMGD rust code in Go, makes sense save for the expansion of these concepts which will expand any refactoring
-  - Figuring it out now minimizes changes but may take awhile as I haven't really gotten my head back around this library, had a different concept in mind originally given separation b/t this and OMGD as a rust lib, which, was exploratory, but anyway, it's a cave I need to get out of (amongst others)
+  - Figuring it out now minimizes changes but may take awhile as I haven't really gotten my head back around this library, had a different concept in mind originally given separation b/t this and OMGD as a rust lib, which, was exploratory, but anyway, it's a cave I need to get out of (amongst others)~~
 
 
 

--- a/cmd/buildTemplates.go
+++ b/cmd/buildTemplates.go
@@ -41,7 +41,9 @@ to quickly create a Cobra application.`,
 			ProfilePath = strings.ReplaceAll(ProfilePath, "profiles/", ".omgd/")
 		}
 
-		utils.BuildTemplatesFromPath(ProfilePath, OutputDir, templateExtension, removeTemplateAfterProcessing, Verbosity)
+		profile := utils.GetProfile(ProfilePath)
+
+		utils.BuildTemplatesFromPath(profile, OutputDir, templateExtension, removeTemplateAfterProcessing, Verbosity)
 	},
 }
 

--- a/cmd/infra.go
+++ b/cmd/infra.go
@@ -24,9 +24,11 @@ $ omgd infra destroy | Destroys cloud infrastructure via terraform`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("infra called")
 
+		profile := utils.GetProfile(ProfilePath)
+
 		infraChange := utils.InfraChange{
 			OutputDir:    OutputDir,
-			ProfilePath:  ProfilePath,
+			Profile:      profile,
 			CmdOnDir:     utils.CmdOnDir,
 			Verbosity:    Verbosity,
 			CopyToTmpDir: CopyToTmpDir,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,11 +29,10 @@ $ omgd run task [name-of-task] [number-of-step (optional)]
 		profile := utils.GetProfile(ProfilePath)
 
 		runner := utils.Run{
-			ProfilePath: ProfilePath,
-			Profile:     profile,
-			OutputDir:   OutputDir,
-			CmdDir:      utils.CmdOnDir,
-			Verbosity:   Verbosity,
+			Profile:   profile,
+			OutputDir: OutputDir,
+			CmdDir:    utils.CmdOnDir,
+			Verbosity: Verbosity,
 		}
 
 		switch len(args) {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/newnoiseworks/omgd/utils"
 	"github.com/spf13/cobra"
@@ -25,8 +24,6 @@ $ omgd server logs --verbose | tails / follows logs continuously
 $ omgd server status         | prints status of running docker containers
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ProfilePath = strings.ReplaceAll(ProfilePath, "profiles/", ".omgd/")
-
 		switch args[0] {
 		case "start":
 			utils.CmdOnDir(

--- a/utils/buildTemplates.go
+++ b/utils/buildTemplates.go
@@ -18,14 +18,14 @@ import (
 var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
 var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
 
-func getData(environment string, buildPath string, verbose bool) *map[interface{}]interface{} {
+func getData(profile *ProfileConf, buildPath string, verbose bool) *map[interface{}]interface{} {
 	fp := make(map[interface{}]interface{})
-	fp["profile"] = GetProfile(environment).GetProfileAsMap()
+	fp["profile"] = profile.GetProfileAsMap()
 
 	resourceDir := buildPath
 
-	if strings.HasPrefix(environment, "..") {
-		paths := strings.Split(environment, "./")
+	if strings.HasPrefix(profile.path, "..") {
+		paths := strings.Split(profile.path, "./")
 
 		resourceDir = ""
 
@@ -81,8 +81,8 @@ func getData(environment string, buildPath string, verbose bool) *map[interface{
 	return &fp
 }
 
-func BuildTemplatesFromPath(environment string, buildPath string, templateExtension string, removeTemplateAfterProcessing bool, verbose bool) {
-	fp := getData(environment, buildPath, verbose)
+func BuildTemplatesFromPath(profile *ProfileConf, buildPath string, templateExtension string, removeTemplateAfterProcessing bool, verbose bool) {
+	fp := getData(profile, buildPath, verbose)
 
 	if verbose {
 		log.Println(fmt.Sprintf("building template files in %s", buildPath))
@@ -107,8 +107,8 @@ func BuildTemplatesFromPath(environment string, buildPath string, templateExtens
 	}
 }
 
-func BuildTemplateFromPath(tmplPath string, environment string, buildPath string, templateExtension string, removeTemplateAfterProcessing bool, verbose bool) {
-	fp := getData(environment, buildPath, verbose)
+func BuildTemplateFromPath(tmplPath string, profile *ProfileConf, buildPath string, templateExtension string, removeTemplateAfterProcessing bool, verbose bool) {
+	fp := getData(profile, buildPath, verbose)
 	processTemplate(tmplPath, fp, templateExtension, removeTemplateAfterProcessing, verbose)
 }
 

--- a/utils/code.go
+++ b/utils/code.go
@@ -55,7 +55,7 @@ func (cp *CodeGenerationPlan) generateNew() {
 	}
 
 	BuildTemplatesFromPath(
-		fmt.Sprintf("%s/profiles/local", outputPath),
+		newProfile,
 		outputPath,
 		"omgdtpl",
 		!cp.SkipCleanup,
@@ -83,7 +83,7 @@ func (cp *CodeGenerationPlan) generateExample2DPlayerMovement() {
 	newProfile.UpdateProfile("omgd.channel_name", cp.Target)
 
 	BuildTemplatesFromPath(
-		fmt.Sprintf("%s/profiles/local", tmpDir),
+		newProfile,
 		tmpDir,
 		"omgdtpl",
 		true,
@@ -148,7 +148,7 @@ func (cp *CodeGenerationPlan) generateChannel() {
 	}
 
 	BuildTemplatesFromPath(
-		fmt.Sprintf("%s/profiles/local", tmpDir),
+		newProfile,
 		tmpDir,
 		"omgdtpl",
 		true,

--- a/utils/code.go
+++ b/utils/code.go
@@ -47,7 +47,7 @@ func (cp *CodeGenerationPlan) generateNew() {
 		log.Fatal(err)
 	}
 
-	newProfile := GetProfile(fmt.Sprintf("%s/profiles/local", outputPath))
+	newProfile := GetProfile(fmt.Sprintf("%s/profiles/local.yml", outputPath))
 	newProfile.UpdateProfile("omgd.name", cp.Target)
 
 	if err != nil {
@@ -79,7 +79,7 @@ func (cp *CodeGenerationPlan) generateExample2DPlayerMovement() {
 		log.Fatal(err)
 	}
 
-	newProfile := GetProfile(fmt.Sprintf("%s/profiles/local", tmpDir))
+	newProfile := GetProfile(fmt.Sprintf("%s/profiles/local.yml", tmpDir))
 	newProfile.UpdateProfile("omgd.channel_name", cp.Target)
 
 	BuildTemplatesFromPath(
@@ -140,7 +140,7 @@ func (cp *CodeGenerationPlan) generateChannel() {
 		log.Fatal(err)
 	}
 
-	newProfile := GetProfile(fmt.Sprintf("%s/profiles/local", tmpDir))
+	newProfile := GetProfile(fmt.Sprintf("%s/profiles/local.yml", tmpDir))
 	newProfile.UpdateProfile("omgd.channel_name", cp.Target)
 
 	if cp.Args != "" {

--- a/utils/code_test.go
+++ b/utils/code_test.go
@@ -263,8 +263,10 @@ func TestCodeGenCmdOMGDChannelCreationWithEventArgs(t *testing.T) {
 		`omgd`,
 	)
 
+	profile := GetProfile("static/test/newProject/.omgd/local")
+
 	BuildTemplatesFromPath(
-		"static/test/newProject/.omgd/local",
+		profile,
 		"static/test/newProject",
 		"tmpl",
 		false,

--- a/utils/code_test.go
+++ b/utils/code_test.go
@@ -23,7 +23,7 @@ func TestCodeGenCmdNewProjectWritesAndCleansUpFiles(t *testing.T) {
 
 	codePlan.Generate()
 
-	localProfile := GetProfile("static/test/newProject/profiles/local")
+	localProfile := GetProfile("static/test/newProject/profiles/local.yml")
 	expected := "newProject"
 	received := localProfile.Get("omgd.name")
 
@@ -71,7 +71,7 @@ func TestCodeGenCmdExample2DPlayerMovement(t *testing.T) {
 
 	codePlan.Generate()
 
-	localProfile := GetProfile("static/test/newProject/.omgdtmp/profiles/local")
+	localProfile := GetProfile("static/test/newProject/.omgdtmp/profiles/local.yml")
 	expected := "movement"
 	received := localProfile.Get("omgd.channel_name")
 
@@ -131,7 +131,7 @@ func TestCodeGenCmdOMGDChannelCreation(t *testing.T) {
 	codePlan.Generate()
 
 	// checks to make sure local.yml in tmp folder gets updated
-	localProfile := GetProfile("static/test/newProject/.omgdtmp/profiles/local")
+	localProfile := GetProfile("static/test/newProject/.omgdtmp/profiles/local.yml")
 	expected := "match_channel"
 	received := localProfile.Get("omgd.channel_name")
 
@@ -233,7 +233,7 @@ func TestCodeGenCmdOMGDChannelCreationWithEventArgs(t *testing.T) {
 	codePlan.Generate()
 
 	// checks to make sure local.yml in tmp folder gets updated w/ events
-	localProfile := GetProfile("static/test/newProject/.omgdtmp/profiles/local")
+	localProfile := GetProfile("static/test/newProject/.omgdtmp/profiles/local.yml")
 	expectedArr := [2]string{"movement", "trade"}
 	receivedArr := localProfile.GetArray("omgd.channel_events")
 
@@ -263,7 +263,7 @@ func TestCodeGenCmdOMGDChannelCreationWithEventArgs(t *testing.T) {
 		`omgd`,
 	)
 
-	profile := GetProfile("static/test/newProject/.omgd/local")
+	profile := GetProfile("static/test/newProject/.omgd/local.yml")
 
 	BuildTemplatesFromPath(
 		profile,

--- a/utils/infra.go
+++ b/utils/infra.go
@@ -9,39 +9,39 @@ import (
 
 type InfraChange struct {
 	OutputDir    string
-	ProfilePath  string
+	Profile      *ProfileConf
 	CmdOnDir     func(string, string, string, bool)
 	Verbosity    bool
-	tmpDir       string
 	CopyToTmpDir bool
+	tmpDir       string
 }
 
 func (infraChange *InfraChange) DeployClientAndServer() {
 	infraChange.setup()
 
 	infraChange.CmdOnDir(
-		fmt.Sprintf("omgd run task set-ip-to-profile --profile=%s", infraChange.ProfilePath),
+		fmt.Sprintf("omgd run task set-ip-to-profile --profile=%s", infraChange.Profile.path),
 		"",
 		infraChange.OutputDir,
 		infraChange.Verbosity,
 	)
 
 	infraChange.CmdOnDir(
-		fmt.Sprintf("omgd build-templates --profile=%s", infraChange.ProfilePath),
+		fmt.Sprintf("omgd build-templates --profile=%s", infraChange.Profile.path),
 		"",
 		infraChange.OutputDir,
 		infraChange.Verbosity,
 	)
 
 	infraChange.CmdOnDir(
-		fmt.Sprintf("omgd build-clients --profile=%s", infraChange.ProfilePath),
+		fmt.Sprintf("omgd build-clients --profile=%s", infraChange.Profile.path),
 		"",
 		infraChange.OutputDir,
 		infraChange.Verbosity,
 	)
 
 	infraChange.CmdOnDir(
-		fmt.Sprintf("omgd run nakama-server --profile=%s", infraChange.ProfilePath),
+		fmt.Sprintf("omgd run nakama-server --profile=%s", infraChange.Profile.path),
 		"",
 		infraChange.OutputDir,
 		infraChange.Verbosity,
@@ -53,7 +53,7 @@ func (infraChange *InfraChange) DeployInfra() {
 
 	// NOTE: Would like to discourage this in favor of using utils.Run but testing is easier this way
 	infraChange.CmdOnDir(
-		fmt.Sprintf("omgd run task deploy-infra --profile=%s", infraChange.ProfilePath),
+		fmt.Sprintf("omgd run task deploy-infra --profile=%s", infraChange.Profile.path),
 		"",
 		infraChange.OutputDir,
 		infraChange.Verbosity,
@@ -65,7 +65,7 @@ func (infraChange *InfraChange) DestroyInfra() {
 
 	// NOTE: Would like to discourage this in favor of using utils.Run but testing is easier this way
 	infraChange.CmdOnDir(
-		fmt.Sprintf("omgd run task destroy-infra --profile=%s", infraChange.ProfilePath),
+		fmt.Sprintf("omgd run task destroy-infra --profile=%s", infraChange.Profile.path),
 		"",
 		infraChange.OutputDir,
 		infraChange.Verbosity,
@@ -73,7 +73,7 @@ func (infraChange *InfraChange) DestroyInfra() {
 }
 
 func (infraChange *InfraChange) setup() {
-	infraChange.ProfilePath = strings.ReplaceAll(infraChange.ProfilePath, "profiles/", ".omgd/")
+	infraChange.Profile.path = strings.ReplaceAll(infraChange.Profile.path, "profiles/", ".omgd/")
 
 	// 1. Should create or empty .omgdtmp directory to work in
 	if infraChange.CopyToTmpDir {

--- a/utils/infra_test.go
+++ b/utils/infra_test.go
@@ -19,9 +19,11 @@ func TestDeployInfra(t *testing.T) {
 		testCmdOnDirResponses = []testCmdOnDirResponse{}
 	})
 
+	profile := GetProfileFromDir("profiles/staging.yml", testDir)
+
 	infraChange := InfraChange{
 		OutputDir:    "static/test/infra_test_dir",
-		ProfilePath:  "profiles/staging",
+		Profile:      profile,
 		CmdOnDir:     testCmdOnDir,
 		Verbosity:    false,
 		CopyToTmpDir: true,
@@ -45,7 +47,7 @@ func TestDeployInfra(t *testing.T) {
 
 	testCmdOnDirValidResponseSet = []testCmdOnDirResponse{
 		{
-			cmdStr:    "omgd run task deploy-infra --profile=.omgd/staging",
+			cmdStr:    "omgd run task deploy-infra --profile=.omgd/staging.yml",
 			cmdDesc:   "",
 			cmdDir:    fmt.Sprintf("%s/.omgdtmp", testDir),
 			verbosity: false,
@@ -69,9 +71,11 @@ func TestDeployClientAndServer(t *testing.T) {
 		testCmdOnDirResponses = []testCmdOnDirResponse{}
 	})
 
+	profile := GetProfileFromDir("profiles/staging.yml", testDir)
+
 	infraChange := InfraChange{
 		OutputDir:    "static/test/infra_test_dir",
-		ProfilePath:  "profiles/staging",
+		Profile:      profile,
 		CmdOnDir:     testCmdOnDir,
 		Verbosity:    false,
 		CopyToTmpDir: true,
@@ -95,25 +99,25 @@ func TestDeployClientAndServer(t *testing.T) {
 
 	testCmdOnDirValidResponseSet = []testCmdOnDirResponse{
 		{
-			cmdStr:    "omgd run task set-ip-to-profile --profile=.omgd/staging",
+			cmdStr:    "omgd run task set-ip-to-profile --profile=.omgd/staging.yml",
 			cmdDesc:   "",
 			cmdDir:    fmt.Sprintf("%s/.omgdtmp", testDir),
 			verbosity: false,
 		},
 		{
-			cmdStr:    "omgd build-templates --profile=.omgd/staging",
+			cmdStr:    "omgd build-templates --profile=.omgd/staging.yml",
 			cmdDesc:   "",
 			cmdDir:    fmt.Sprintf("%s/.omgdtmp", testDir),
 			verbosity: false,
 		},
 		{
-			cmdStr:    "omgd build-clients --profile=.omgd/staging",
+			cmdStr:    "omgd build-clients --profile=.omgd/staging.yml",
 			cmdDesc:   "",
 			cmdDir:    fmt.Sprintf("%s/.omgdtmp", testDir),
 			verbosity: false,
 		},
 		{
-			cmdStr:    "omgd run nakama-server --profile=.omgd/staging",
+			cmdStr:    "omgd run nakama-server --profile=.omgd/staging.yml",
 			cmdDesc:   "",
 			cmdDir:    fmt.Sprintf("%s/.omgdtmp", testDir),
 			verbosity: false,
@@ -137,9 +141,11 @@ func TestDeployInfraWithoutCopying(t *testing.T) {
 		testCmdOnDirResponses = []testCmdOnDirResponse{}
 	})
 
+	profile := GetProfileFromDir("profiles/staging.yml", testDir)
+
 	infraChange := InfraChange{
 		OutputDir:    "static/test/infra_test_dir",
-		ProfilePath:  "profiles/staging",
+		Profile:      profile,
 		CmdOnDir:     testCmdOnDir,
 		Verbosity:    false,
 		CopyToTmpDir: false,
@@ -163,7 +169,7 @@ func TestDeployInfraWithoutCopying(t *testing.T) {
 
 	testCmdOnDirValidResponseSet = []testCmdOnDirResponse{
 		{
-			cmdStr:    "omgd run task deploy-infra --profile=.omgd/staging",
+			cmdStr:    "omgd run task deploy-infra --profile=.omgd/staging.yml",
 			cmdDesc:   "",
 			cmdDir:    testDir,
 			verbosity: false,
@@ -183,13 +189,13 @@ func TestDestroyInfra(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		testCmdOnDirResponses = []testCmdOnDirResponse{}
 	})
+
+	profile := GetProfileFromDir("profiles/staging.yml", testDir)
 
 	infraChange := InfraChange{
 		OutputDir:    "static/test/infra_test_dir",
-		ProfilePath:  "profiles/staging",
+		Profile:      profile,
 		CmdOnDir:     testCmdOnDir,
 		Verbosity:    false,
 		CopyToTmpDir: true,
@@ -213,7 +219,7 @@ func TestDestroyInfra(t *testing.T) {
 
 	testCmdOnDirValidResponseSet = []testCmdOnDirResponse{
 		{
-			cmdStr:    "omgd run task destroy-infra --profile=.omgd/staging",
+			cmdStr:    "omgd run task destroy-infra --profile=.omgd/staging.yml",
 			cmdDesc:   "",
 			cmdDir:    fmt.Sprintf("%s/.omgdtmp", testDir),
 			verbosity: false,

--- a/utils/profile.go
+++ b/utils/profile.go
@@ -152,9 +152,11 @@ func BuildProfiles(dir string, verbose bool) {
 		ext := splits[len(splits)-1]
 
 		if ext == "yml" && splits[0] != "example" {
+			profile := GetProfile(fmt.Sprintf("%s/profiles/%s", dir, strings.Replace(file.Name(), ".yml", "", 1)))
+
 			BuildTemplateFromPath(
 				fmt.Sprintf("%s/profiles/profile.yml.omgdptpl", dir),
-				fmt.Sprintf("%s/profiles/%s", dir, strings.Replace(file.Name(), ".yml", "", 1)),
+				profile,
 				fmt.Sprintf("%s/profiles", dir),
 				"omgdptpl",
 				false,

--- a/utils/profile.go
+++ b/utils/profile.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -31,7 +33,6 @@ type ProfileConf struct {
 	Main  []CommandConfig `yaml:"main"`
 	Tasks []CommandConfig `yaml:"tasks"`
 	path  string
-	env   string
 }
 
 func (pc ProfileConf) GetProfileAsMap() map[interface{}]interface{} {
@@ -51,14 +52,14 @@ func (pc ProfileConf) GetProfileAsMap() map[interface{}]interface{} {
 	return c
 }
 
-func GetProfile(env string) *ProfileConf {
+func GetProfile(path string) *ProfileConf {
 	c := ProfileConf{
-		env:  env,
-		path: fmt.Sprintf("%s.yml", env),
+		path: path,
 	}
 
 	yamlFile, err := os.ReadFile(c.path)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatalf("yamlFile Get err: #%v ", err)
 	}
 	err = yaml.Unmarshal(yamlFile, &c)
@@ -66,10 +67,31 @@ func GetProfile(env string) *ProfileConf {
 		log.Fatalf("Unmarshal err: %v", err)
 	}
 
-	splits := strings.Split(env, "/")
+	splits := strings.Split(path, "/")
 	c.Name = splits[len(splits)-1]
 
 	return &c
+}
+
+func GetProfileFromDir(path string, dir string) *ProfileConf {
+	root, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = os.Chdir(filepath.Join(root, dir))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	profile := GetProfile(path)
+
+	err = os.Chdir(root)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return profile
 }
 
 func (profile ProfileConf) SaveProfileFromMap(profileMap *map[interface{}]interface{}) {
@@ -152,7 +174,7 @@ func BuildProfiles(dir string, verbose bool) {
 		ext := splits[len(splits)-1]
 
 		if ext == "yml" && splits[0] != "example" {
-			profile := GetProfile(fmt.Sprintf("%s/profiles/%s", dir, strings.Replace(file.Name(), ".yml", "", 1)))
+			profile := GetProfile(fmt.Sprintf("%s/profiles/%s", dir, file.Name()))
 
 			BuildTemplateFromPath(
 				fmt.Sprintf("%s/profiles/profile.yml.omgdptpl", dir),

--- a/utils/run.go
+++ b/utils/run.go
@@ -7,11 +7,10 @@ import (
 
 // Run doc
 type Run struct {
-	Profile     *ProfileConf
-	ProfilePath string
-	OutputDir   string
-	CmdDir      func(string, string, string, bool)
-	Verbosity   bool
+	Profile   *ProfileConf
+	OutputDir string
+	CmdDir    func(string, string, string, bool)
+	Verbosity bool
 }
 
 func (r *Run) runCmdOnDir(cmd string, cmdDesc string, cmdDir string) {
@@ -38,13 +37,13 @@ func (r *Run) runCmdOnDir(cmd string, cmdDesc string, cmdDir string) {
 			pathPrepend += "../"
 		}
 
-		cmd = cmd + " --profile=" + pathPrepend + r.ProfilePath
+		cmd = cmd + " --profile=" + pathPrepend + r.Profile.path
 	}
 
 	r.CmdDir(cmd, cmdDesc, cmdDir, r.Verbosity)
 
 	if strings.HasSuffix(baseCmd, "omgd") && strings.Contains(cmd, "update-profile") {
-		r.Profile = GetProfile(r.Profile.arg)
+		r.Profile = GetProfile(r.Profile.path)
 	}
 }
 

--- a/utils/run.go
+++ b/utils/run.go
@@ -44,7 +44,7 @@ func (r *Run) runCmdOnDir(cmd string, cmdDesc string, cmdDir string) {
 	r.CmdDir(cmd, cmdDesc, cmdDir, r.Verbosity)
 
 	if strings.HasSuffix(baseCmd, "omgd") && strings.Contains(cmd, "update-profile") {
-		r.Profile = GetProfile(r.Profile.env)
+		r.Profile = GetProfile(r.Profile.arg)
 	}
 }
 

--- a/utils/run_test.go
+++ b/utils/run_test.go
@@ -7,19 +7,18 @@ import (
 func TestRunnerCmd(t *testing.T) {
 	testCmdOnDirResponses = nil
 
-	profile := GetProfile("../profiles/test.yml")
+	profile := GetProfileFromDir("profiles/test.yml", "..")
 
 	runner := Run{
-		OutputDir:   ".",
-		CmdDir:      testCmdOnDir,
-		Profile:     profile,
-		ProfilePath: "profiles/test",
-		Verbosity:   false,
+		OutputDir: ".",
+		CmdDir:    testCmdOnDir,
+		Profile:   profile,
+		Verbosity: false,
 	}
 
 	testCmdOnDirValidResponseSet = []testCmdOnDirResponse{
 		{
-			cmdStr:  "omgd build-templates --profile=../../profiles/test",
+			cmdStr:  "omgd build-templates --profile=../../profiles/test.yml",
 			cmdDesc: "builds infra templates",
 			cmdDir:  "./server/infra",
 		},
@@ -29,7 +28,7 @@ func TestRunnerCmd(t *testing.T) {
 			cmdDir:  "./server/infra/gcp",
 		},
 		{
-			cmdStr:  "omgd build-templates --profile=../profiles/test",
+			cmdStr:  "omgd build-templates --profile=../profiles/test.yml",
 			cmdDesc: "",
 			cmdDir:  "./game",
 		},

--- a/utils/run_test.go
+++ b/utils/run_test.go
@@ -7,7 +7,7 @@ import (
 func TestRunnerCmd(t *testing.T) {
 	testCmdOnDirResponses = nil
 
-	profile := GetProfile("../profiles/test")
+	profile := GetProfile("../profiles/test.yml")
 
 	runner := Run{
 		OutputDir:   ".",


### PR DESCRIPTION
closes #80 

stops using env and path in ProfileConf, reduces path manipulation to cmd package if needed, makes code changes elsewhere and in tests as needed