### PR TITLE
renames tfsettings bucket to gcp

### DIFF
--- a/utils/cmdOnDir_test.go
+++ b/utils/cmdOnDir_test.go
@@ -26,7 +26,7 @@ var testCmdOnDir = func(cmdStr string, cmdDesc string, cmdDir string) string {
 	if cmdStr == "terraform output -raw server_ip" {
 		return "127.6.6.6"
 	} else if cmdStr == "terraform output -raw bucket_name" {
-		return "omgd.tfsettings.bucket"
+		return "omgd.gcp.bucket"
 	}
 
 	return ""

--- a/utils/infra.go
+++ b/utils/infra.go
@@ -22,7 +22,7 @@ func (infraChange *InfraChange) DeployClientAndServer() {
 	BuildTemplatesFromPath(infraChange.Profile, infraChange.OutputDir, "tmpl", false)
 
 	infraChange.CmdOnDir(
-		fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", infraChange.Profile.Get("omgd.tfsettings.bucket"), infraChange.Profile.Get("omgd.name"), infraChange.Profile.Name),
+		fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", infraChange.Profile.Get("omgd.gcp.bucket"), infraChange.Profile.Get("omgd.name"), infraChange.Profile.Name),
 		fmt.Sprintf("setting up terraform on profile %s", infraChange.Profile.Name),
 		fmt.Sprintf("%s/.omgd/infra/gcp/instance-setup/", infraChange.OutputDir),
 	)
@@ -65,7 +65,7 @@ func (infraChange *InfraChange) DeployInfra() {
 	BuildTemplatesFromPath(infraChange.Profile, infraChange.OutputDir, "tmpl", false)
 
 	infraChange.CmdOnDir(
-		fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", infraChange.Profile.Get("omgd.tfsettings.bucket"), infraChange.Profile.Get("omgd.name"), infraChange.Profile.Name),
+		fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", infraChange.Profile.Get("omgd.gcp.bucket"), infraChange.Profile.Get("omgd.name"), infraChange.Profile.Name),
 		"setting up terraform locally",
 		fmt.Sprintf("%s/.omgd/infra/gcp/instance-setup/", infraChange.OutputDir),
 	)
@@ -95,7 +95,7 @@ func (infraChange *InfraChange) DestroyInfra() {
 	BuildTemplatesFromPath(infraChange.Profile, infraChange.OutputDir, "tmpl", false)
 
 	infraChange.CmdOnDir(
-		fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", infraChange.Profile.Get("omgd.tfsettings.bucket"), infraChange.Profile.Get("omgd.name"), infraChange.Profile.Name),
+		fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", infraChange.Profile.Get("omgd.gcp.bucket"), infraChange.Profile.Get("omgd.name"), infraChange.Profile.Name),
 		fmt.Sprintf("setting up terraform on profile %s", infraChange.Profile.Name),
 		fmt.Sprintf("%s/.omgd/infra/gcp/instance-setup/", infraChange.OutputDir),
 	)
@@ -140,13 +140,13 @@ func (infraChange *InfraChange) ProjectSetup() {
 		"omgd.yml",
 		1,
 	), infraChange.Profile.rootDir)
-	omgdProfile.UpdateProfile("omgd.tfsettings.bucket", bucketName)
+	omgdProfile.UpdateProfile("omgd.gcp.bucket", bucketName)
 
 	tfFilePath := fmt.Sprintf("%s/.omgd/infra/gcp/project-setup/main.tf", infraChange.OutputDir)
 	infraChange.alterInfraBackendFile(tfFilePath, true)
 
 	infraChange.CmdOnDir(
-		fmt.Sprintf("terraform init -force-copy -backend-config bucket=%s -backend-config prefix=terraform/state/%s", infraChange.Profile.Get("omgd.tfsettings.bucket"), infraChange.Profile.Get("omgd.name")),
+		fmt.Sprintf("terraform init -force-copy -backend-config bucket=%s -backend-config prefix=terraform/state/%s", infraChange.Profile.Get("omgd.gcp.bucket"), infraChange.Profile.Get("omgd.name")),
 		"setting up terraform to use gcs backend",
 		fmt.Sprintf("%s/.omgd/infra/gcp/project-setup/", infraChange.OutputDir),
 	)
@@ -165,7 +165,7 @@ func (infraChange *InfraChange) ProjectDestroy() {
 	infraChange.alterInfraBackendFile(tfFilePath, true)
 
 	infraChange.CmdOnDir(
-		fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s", infraChange.Profile.Get("omgd.tfsettings.bucket"), infraChange.Profile.Get("omgd.name")),
+		fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s", infraChange.Profile.Get("omgd.gcp.bucket"), infraChange.Profile.Get("omgd.name")),
 		"setting up terraform to local backend",
 		fmt.Sprintf("%s/.omgd/infra/gcp/project-setup/", infraChange.OutputDir),
 	)

--- a/utils/infra_test.go
+++ b/utils/infra_test.go
@@ -59,7 +59,7 @@ func TestDeployInfra(t *testing.T) {
 
 	testCmdOnDirValidResponseSet = []testCmdOnDirResponse{
 		{
-			cmdStr:  fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", profile.Get("omgd.tfsettings.bucket"), profile.Get("omgd.name"), profile.Name),
+			cmdStr:  fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", profile.Get("omgd.gcp.bucket"), profile.Get("omgd.name"), profile.Name),
 			cmdDesc: "setting up terraform locally",
 			cmdDir:  cmdDirStrTf,
 		},
@@ -134,7 +134,7 @@ func TestDestroyInfra(t *testing.T) {
 
 	testCmdOnDirValidResponseSet = []testCmdOnDirResponse{
 		{
-			cmdStr:  fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", profile.Get("omgd.tfsettings.bucket"), profile.Get("omgd.name"), profile.Name),
+			cmdStr:  fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", profile.Get("omgd.gcp.bucket"), profile.Get("omgd.name"), profile.Name),
 			cmdDesc: fmt.Sprintf("setting up terraform on profile %s", profile.Name),
 			cmdDir:  cmdDirStrTf,
 		},
@@ -205,7 +205,7 @@ func TestDeployClientAndServer(t *testing.T) {
 
 	testCmdOnDirValidResponseSet = []testCmdOnDirResponse{
 		{
-			cmdStr:  fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", profile.Get("omgd.tfsettings.bucket"), profile.Get("omgd.name"), profile.Name),
+			cmdStr:  fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s/%s", profile.Get("omgd.gcp.bucket"), profile.Get("omgd.name"), profile.Name),
 			cmdDesc: fmt.Sprintf("setting up terraform on profile %s", profile.Name),
 			cmdDir:  cmdDirStrTf,
 		},
@@ -259,7 +259,7 @@ func TestProjectSetup(t *testing.T) {
 
 		profile.UpdateProfile("omgd.servers.host", "???")
 
-		GetProfileFromDir("profiles/omgd.yml", testDir).UpdateProfile("omgd.tfsettings.bucket", "???")
+		GetProfileFromDir("profiles/omgd.yml", testDir).UpdateProfile("omgd.gcp.bucket", "???")
 	})
 
 	profile := GetProfileFromDir("profiles/staging.yml", testDir)
@@ -281,7 +281,7 @@ func TestProjectSetup(t *testing.T) {
 
 	testForFileAndRegexpMatch(t, fmt.Sprintf("%s/.omgd/infra/gcp/project-setup/main.tf", testDir), "gcs")
 
-	if GetProfileFromDir("profiles/omgd.yml", testDir).Get("omgd.tfsettings.bucket") != "omgd.tfsettings.bucket" {
+	if GetProfileFromDir("profiles/omgd.yml", testDir).Get("omgd.gcp.bucket") != "omgd.gcp.bucket" {
 		LogError("Bucket name not being set in profile")
 		t.Fail()
 	}
@@ -303,7 +303,7 @@ func TestProjectSetup(t *testing.T) {
 			cmdDir:  cmdDirStrTf,
 		},
 		{
-			cmdStr:  fmt.Sprintf("terraform init -force-copy -backend-config bucket=%s -backend-config prefix=terraform/state/%s", profile.Get("omgd.tfsettings.bucket"), profile.Get("omgd.name")),
+			cmdStr:  fmt.Sprintf("terraform init -force-copy -backend-config bucket=%s -backend-config prefix=terraform/state/%s", profile.Get("omgd.gcp.bucket"), profile.Get("omgd.name")),
 			cmdDesc: "setting up terraform to use gcs backend",
 			cmdDir:  cmdDirStrTf,
 		},
@@ -360,7 +360,7 @@ func TestProjectDestroy(t *testing.T) {
 
 	testCmdOnDirValidResponseSet = []testCmdOnDirResponse{
 		{
-			cmdStr:  fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s", profile.Get("omgd.tfsettings.bucket"), profile.Get("omgd.name")),
+			cmdStr:  fmt.Sprintf("terraform init -reconfigure -backend-config bucket=%s -backend-config prefix=terraform/state/%s", profile.Get("omgd.gcp.bucket"), profile.Get("omgd.name")),
 			cmdDesc: "setting up terraform to local backend",
 			cmdDir:  cmdDirStrTf,
 		},

--- a/utils/static/test/infra_test_dir/profiles/omgd.yml
+++ b/utils/static/test/infra_test_dir/profiles/omgd.yml
@@ -1,8 +1,7 @@
 omgd:
   gcp:
+    bucket: ???
     project: test
     zone: us-east4c
   name: top-level-name
   override: not-overriden
-  tfsettings:
-    bucket: ???


### PR DESCRIPTION
- tests against example headless project
- stores bucket name in `omgd.gcp` block as opposed to `omgd.tfsettings` for solidity, also "bucket" is a more or less universal name