### PR TITLE
adds docker compose as plugin install to top of deploy script

### DIFF
--- a/utils/cmdOnDir.go
+++ b/utils/cmdOnDir.go
@@ -24,6 +24,8 @@ func CmdOnDirWithEnv(cmdStr string, cmdDesc string, cmdDir string, env []string)
 		cmd.Env = append(cmd.Env, envVar)
 	}
 
+	LogDebug(fmt.Sprintf("providing env args %s", strings.Join(env, " ")))
+
 	return runCmd(cmd, cmdStr, cmdDir)
 }
 

--- a/utils/static/deploy/gcp/deploy.sh
+++ b/utils/static/deploy/gcp/deploy.sh
@@ -2,19 +2,16 @@
 
 export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=~/.config/gcloud/application_default_credentials.json
 
+gcloud compute ssh --project ${GCP_PROJECT} --zone ${GCP_ZONE} --command "sudo curl -sSL https://github.com/docker/compose/releases/download/v2.23.3/docker-compose-linux-x86_64 -o /var/lib/google/docker-compose && sudo chmod o+x /var/lib/google/docker-compose && mkdir -p ~/.docker/cli-plugins && sudo ln -sf /var/lib/google/docker-compose ~/.docker/cli-plugins/docker-compose" ${OMGD_PROJECT}-omgd-dev-instance-${OMGD_PROFILE}
+
 gcloud compute ssh --project ${GCP_PROJECT} --zone ${GCP_ZONE} --command "truncate -s 0 /var/log/docker.log" ${OMGD_PROJECT}-omgd-dev-instance-${OMGD_PROFILE}
 
 # scp'ing the docker-compose file in case it's the first deploy and we don't have one, so the subsequent down command won't error out
 gcloud compute scp --project ${GCP_PROJECT} --zone ${GCP_ZONE} --force-key-file-overwrite ../../../servers/docker-compose.yml ${OMGD_PROJECT}-omgd-dev-instance-${OMGD_PROFILE}:
 
-# $GCP_UPDATE_REMOVE_VOLUME not set, then...
-if [[ -z "${GCP_UPDATE_REMOVE_VOLUME}" ]]; then
-    gcloud compute ssh --project ${GCP_PROJECT} --zone ${GCP_ZONE} --command "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "\$PWD:\$PWD" -w="\$PWD" docker/compose:1.27.0 down" ${OMGD_PROJECT}-omgd-dev-instance-${OMGD_PROFILE}
-else
-    gcloud compute ssh --project ${GCP_PROJECT} --zone ${GCP_ZONE} --command "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "\$PWD:\$PWD" -w="\$PWD" docker/compose:1.27.0 down -v" ${OMGD_PROJECT}-omgd-dev-instance-${OMGD_PROFILE}
-fi
+gcloud compute ssh --project ${GCP_PROJECT} --zone ${GCP_ZONE} --command "docker compose down" ${OMGD_PROJECT}-omgd-dev-instance-${OMGD_PROFILE}
 
 gcloud compute scp --project ${GCP_PROJECT} --zone ${GCP_ZONE} --recurse --force-key-file-overwrite ../../../servers/* ${OMGD_PROJECT}-omgd-dev-instance-${OMGD_PROFILE}:
 
-gcloud compute ssh --project ${GCP_PROJECT} --zone ${GCP_ZONE} --command "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "\$PWD:\$PWD" -w="\$PWD" docker/compose:1.27.0 up -d ${OMGD_SERVER_SERVICES}" ${OMGD_PROJECT}-omgd-dev-instance-${OMGD_PROFILE}
+gcloud compute ssh --project ${GCP_PROJECT} --zone ${GCP_ZONE} --command "docker compose up -d ${OMGD_SERVER_SERVICES}" ${OMGD_PROJECT}-omgd-dev-instance-${OMGD_PROFILE}
 


### PR DESCRIPTION
closes #260 

I attempted to at first run this as a separate script immediately after the setup of the instance but got errors saying ssh was refusing a connection

I'm guessing this works due to the pause between `omgd infra deploy` and `omgd infra game-deploy`, but that's fine

it doesn't appear that re-installing the plugin does anything terrible here, so keeping this approach for now though it could be better admittedly