### PR TITLE
285 doc updates should not affect releases

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+      - 285-doc-updates-should-not-affect-releases
+    paths:
+      - 'docs/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - 285-doc-updates-should-not-affect-releases
     paths:
       - 'docs/**'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 285-doc-updates-should-not-affect-releases
     paths:
       - 'cmd/**'
       - 'utils/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      - 285-doc-updates-should-not-affect-releases
+    paths:
+      - 'cmd/**'
+      - 'utils/**'
 
 permissions:
   contents: write

--- a/docs/content/pages/getting-started.md
+++ b/docs/content/pages/getting-started.md
@@ -37,7 +37,7 @@ Then, in the directory of the project on your computer, run
 
 ```console
 omgd game build
-omgd server start
+omgd servers start
 ```
 
 In the `game/dist` directory, there should be built executables mapped to your local server. Launch a couple to try the demo out!


### PR DESCRIPTION
closes #285 

not 100% sure it is working until a release is tested and it does NOT update the docs

while in the branch, it seemed that updating the docs did NOT run the release update as well, so it should work.

will reopen the ticket if this doesn't work though

on merging to main, it _should_ cause a docs update though, so that's testing half of this for working code